### PR TITLE
Ensure log formatter doesn't fail with non json-serializable params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage.xml
 docs/_build
 build
 dist
+*.pyc

--- a/src/dockerflow/logging.py
+++ b/src/dockerflow/logging.py
@@ -8,6 +8,11 @@ import socket
 import traceback
 
 
+class SafeJSONEncoder(json.JSONEncoder):
+    def default(self, o):
+        return repr(o)
+
+
 class JsonLogFormatter(logging.Formatter):
     """Log formatter that outputs machine-readable json.
 
@@ -85,7 +90,7 @@ class JsonLogFormatter(logging.Formatter):
 
         out['Fields'] = fields
 
-        return json.dumps(out)
+        return json.dumps(out, cls=SafeJSONEncoder)
 
 
 def safer_format_traceback(exc_typ, exc_val, exc_tb):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -48,6 +48,20 @@ def test_custom_paramters(caplog):
     assert details['Fields']['more'] == 'stuff'
 
 
+def test_non_json_serializable_parameters_are_converted(caplog):
+    """Ensure log formatter doesn't fail with non json-serializable params."""
+    foo = object()
+    foo_repr = repr(foo)
+    logger = logging.getLogger('dockerflow.test.test_logging')
+    logger.warning('custom test %s', 'hello', extra={'foo': foo})
+    details = assert_records(caplog.records)
+
+    assert details['Type'] == 'dockerflow.test.test_logging'
+    assert details['Severity'] == 4
+    assert details['Fields']['message'] == 'custom test hello'
+    assert details['Fields']['foo'] == foo_repr
+
+
 def test_logging_error_tracebacks(caplog):
     """Ensure log formatter includes exception traceback information"""
     try:


### PR DESCRIPTION
Fix #8

It could be argued that using `o.__dict__` instead of `repr(o)` might be better for some users, but I thought it would be too verbose for the generic case. Maybe it would be worth allowing easy customization of the encoder class in `JsonLogFormatter` instead, but I went for the simpler patch.