### PR TITLE
logging: allow subclasses to override json serialization.

### DIFF
--- a/src/dockerflow/logging.py
+++ b/src/dockerflow/logging.py
@@ -101,7 +101,11 @@ class JsonLogFormatter(logging.Formatter):
 
         out['Fields'] = fields
 
-        return json.dumps(out, cls=SafeJSONEncoder)
+        return self.serialize(out)
+
+    def serialize(self, obj):
+        """Serialize log dictionary into JSON for output."""
+        return json.dumps(obj, cls=SafeJSONEncoder)
 
 
 def safer_format_traceback(exc_typ, exc_val, exc_tb):


### PR DESCRIPTION
It can be very useful to consumers of the dockerflow library to override
the json serialization used by the JsonLogFormatter. This allows custom
serialization of specific object types (Currently handled by the
SafeJSONEncoder).

My specific use case for this functionality is allowing dockerflow
library users to create a "Pretty" formatter to be used when in DEBUG
mode, such as the following:

```
class PrettyJsonLogFormatter(JsonLogFormatter):
    """Log formatter that outputs human-readable json."""

    def serialize(obj):
        """Serialize to sorted multi-line json."""
        return json.dumps(obj, cls=SafeJSONEncoder, sort_keys=True, indent=2)
```