### PR TITLE
Match Django urlpatterns with trailing slash

### DIFF
--- a/src/dockerflow/django/middleware.py
+++ b/src/dockerflow/django/middleware.py
@@ -30,9 +30,9 @@ class DockerflowMiddleware(MiddlewareMixin):
     https://github.com/mozilla-services/Dockerflow/blob/master/docs/mozlog.md
     """
     viewpatterns = [
-        (re.compile(r'/__version__$'), views.version),
-        (re.compile(r'/__heartbeat__$'), views.heartbeat),
-        (re.compile(r'/__lbheartbeat__$'), views.lbheartbeat),
+        (re.compile(r'/__version__/?$'), views.version),
+        (re.compile(r'/__heartbeat__/?$'), views.heartbeat),
+        (re.compile(r'/__lbheartbeat__/?$'), views.lbheartbeat),
     ]
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
In current versions of Django if you use the CommonMiddleware and don't
explicitly set APPEND_SLASH to False, Django will redirect all URLs to
contain an appended slash. We want to support both with and without.