### PR TITLE
Make JsonLogFormatter easier to extend

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -63,6 +63,7 @@ def test_basic_operation(caplog):
     caplog.set_level(logging.DEBUG)
     logging.debug(message_text)
     details = assert_records(caplog.records)
+    assert details == formatter.convert_record(caplog.records[0])
 
     assert "Timestamp" in details
     assert "Hostname" in details
@@ -79,6 +80,7 @@ def test_custom_paramters(caplog):
     logger = logging.getLogger("tests.test_logging")
     logger.warning("custom test %s", "one", extra={"more": "stuff"})
     details = assert_records(caplog.records)
+    assert details == formatter.convert_record(caplog.records[0])
 
     assert details["Type"] == "tests.test_logging"
     assert details["Severity"] == 4
@@ -123,6 +125,10 @@ def test_ignore_json_message(caplog):
         logging.exception(json.dumps({"spam": "eggs"}))
     details = assert_records(caplog.records)
     assert "msg" not in details["Fields"]
+
+    assert formatter.is_value_jsonlike('{"spam": "eggs"}')
+    assert not formatter.is_value_jsonlike('{"spam": "eggs"')
+    assert not formatter.is_value_jsonlike('"spam": "eggs"}')
 
 
 # https://mana.mozilla.org/wiki/pages/viewpage.action?pageId=42895640


### PR DESCRIPTION
Ref https://github.com/mozilla-services/python-dockerflow/issues/29
Ref https://github.com/mozilla/addons-server/issues/11724

AMO has switched to Stackdriver, but we're still using python-dockerflow's `JsonLogFormatter` to adhere to MozLog standard. We'd like to augment the logs to leverage more Stackdriver functionality, so this is what I came up with to help us. While I was at it I added a separate method to help with #29 because it was a good proof of concept regarding ease of extensibility.

Let me know if you consider this is going too far for you - but my alternative is pretty much copy/pasting and modifying this code in our repos...