### PR TITLE
Fix docs build by using autoclass directly

### DIFF
--- a/docs/api/flask.rst
+++ b/docs/api/flask.rst
@@ -7,7 +7,10 @@ internals of the extension.
 Extension
 ---------
 
-.. automodule:: dockerflow.flask.app
+.. autoclass:: dockerflow.flask.app.Dockerflow
+   :members:
+
+.. autoclass:: dockerflow.flask.app.HeartbeatFailure
    :members:
 
 .. _flask-checks:


### PR DESCRIPTION
The Sphinx directive ``automodule`` loads the module in a way that triggers a Flask exception:

```
RuntimeError: Working outside of application context.
```

Instead, use ``autoclass`` to document the two classes in ``dockerflow.flask.app`` directly.