### PR TITLE
Handle exc_info=False in logging formatter

### DIFF
--- a/src/dockerflow/logging.py
+++ b/src/dockerflow/logging.py
@@ -123,7 +123,7 @@ class JsonLogFormatter(logging.Formatter):
             fields["msg"] = message
 
         # If there is an error, format it for nice output.
-        if record.exc_info is not None:
+        if record.exc_info:
             fields["error"] = repr(record.exc_info[1])
             fields["traceback"] = safer_format_traceback(*record.exc_info)
 

--- a/tests/core/test_logging.py
+++ b/tests/core/test_logging.py
@@ -5,11 +5,12 @@ import json
 import logging
 import logging.config
 import os
-import textwrap
 import sys
+import textwrap
 
 import jsonschema
 import pytest
+
 from dockerflow.logging import JsonLogFormatter
 
 logger_name = "tests"

--- a/tests/core/test_logging.py
+++ b/tests/core/test_logging.py
@@ -116,6 +116,21 @@ def test_logging_error_tracebacks(caplog):
     assert "ValueError" in details["Fields"]["traceback"]
 
 
+def test_logging_exc_info_false(caplog):
+    """Ensure log formatter does not include exception traceback information
+    when exc_info is False"""
+    try:
+        raise ValueError("\n")
+    except Exception:
+        logging.exception("there was an error", exc_info=False)
+    details = assert_records(caplog.records)
+
+    assert details["Severity"] == 3
+    assert details["Fields"]["msg"] == "there was an error"
+    assert 'error' not in details["Fields"]
+    assert 'traceback' not in details["Fields"]
+
+
 def test_ignore_json_message(caplog):
     """Ensure log formatter ignores messages that are JSON already"""
     try:

--- a/tests/core/test_logging.py
+++ b/tests/core/test_logging.py
@@ -127,8 +127,8 @@ def test_logging_exc_info_false(caplog):
 
     assert details["Severity"] == 3
     assert details["Fields"]["msg"] == "there was an error"
-    assert 'error' not in details["Fields"]
-    assert 'traceback' not in details["Fields"]
+    assert "error" not in details["Fields"]
+    assert "traceback" not in details["Fields"]
 
 
 def test_ignore_json_message(caplog):

--- a/tests/core/test_logging.py
+++ b/tests/core/test_logging.py
@@ -6,8 +6,10 @@ import logging
 import logging.config
 import os
 import textwrap
+import sys
 
 import jsonschema
+import pytest
 from dockerflow.logging import JsonLogFormatter
 
 logger_name = "tests"
@@ -116,9 +118,10 @@ def test_logging_error_tracebacks(caplog):
     assert "ValueError" in details["Fields"]["traceback"]
 
 
-def test_logging_exc_info_false(caplog):
-    """Ensure log formatter does not include exception traceback information
-    when exc_info is False"""
+@pytest.mark.skipif(sys.version_info < (3, 5), reason="Requires python >= 3.5")
+def test_logging_exc_info_false_3x(caplog):
+    """Ensure log formatter does not fail and does not include exception
+    traceback information when exc_info is False under Python 3.x"""
     try:
         raise ValueError("\n")
     except Exception:
@@ -129,6 +132,25 @@ def test_logging_exc_info_false(caplog):
     assert details["Fields"]["msg"] == "there was an error"
     assert "error" not in details["Fields"]
     assert "traceback" not in details["Fields"]
+
+
+@pytest.mark.skipif(sys.version_info >= (3,), reason="Requires python 2")
+def test_logging_exc_info_false_2x(caplog):
+    """Ensure log formatter does not fail *but* still includes exception
+    traceback information when exc_info is False under Python 2.x"""
+    try:
+        raise ValueError("\n")
+    except Exception:
+        logging.exception("there was an error", exc_info=False)
+    details = assert_records(caplog.records)
+
+    assert details["Severity"] == 3
+    assert details["Fields"]["msg"] == "there was an error"
+    # In Python 2, when exc_info=False is passed, we still see a tuple in the
+    # formatter, so we still include the error and traceback keys.
+    assert details["Fields"]["error"].startswith("ValueError('\\n'")
+    assert details["Fields"]["traceback"].startswith("Uncaught exception:")
+    assert "ValueError" in details["Fields"]["traceback"]
 
 
 def test_ignore_json_message(caplog):

--- a/tests/core/test_logging.py
+++ b/tests/core/test_logging.py
@@ -10,7 +10,6 @@ import textwrap
 
 import jsonschema
 import pytest
-
 from dockerflow.logging import JsonLogFormatter
 
 logger_name = "tests"


### PR DESCRIPTION
https://docs.python.org/3/library/logging.html#logrecord-objects mentions `exc_info` should be a tuple or `None`, but `False` can be passed to a log statement according to https://docs.python.org/3/library/logging.html#logging.debug and when that happens, the `exc_info` on the `LogRecord` object *will* be `False` as well, so we need to handle that to avoid crashing.

This isn't a theoretical case, [there is code in the wild using `exc_info=False`](https://github.com/elastic/elasticsearch-py/blob/24524fa6c37b1310092a768eb21a2fdfe9d520d3/elasticsearch/connection/base.py#L256) and that causes a crash with python-dockerflow logging.

Fixes #46