### PR TITLE
handle exceptions from Django checks

### DIFF
--- a/src/dockerflow/django/views.py
+++ b/src/dockerflow/django/views.py
@@ -69,7 +69,10 @@ def heartbeat(request):
 
 
 def heartbeat_check_detail(check):
-    errors = check(app_configs=None)
+    try:
+        errors = check(app_configs=None)
+    except Exception as ex:
+        errors = [checks.Error(f"check {check} raised exception {ex}")]
     errors = list(filter(lambda e: e.id not in settings.SILENCED_SYSTEM_CHECKS, errors))
     level = max([0] + [e.level for e in errors])
 

--- a/tests/django/django_checks.py
+++ b/tests/django/django_checks.py
@@ -12,3 +12,8 @@ def error(app_configs, **kwargs):
 @checks.register
 def warning(app_configs, **kwargs):
     return [checks.Warning("some warning", id="tests.checks.W001")]
+
+
+@checks.register
+def exception(app_configs, **kwargs):
+    raise RuntimeError("uhoh")

--- a/tests/django/test_django.py
+++ b/tests/django/test_django.py
@@ -65,6 +65,7 @@ def test_heartbeat(dockerflow_middleware, reset_checks, rf, settings):
     settings.DOCKERFLOW_CHECKS = [
         "tests.django.django_checks.warning",
         "tests.django.django_checks.error",
+        "tests.django.django_checks.exception",
     ]
     checks.register()
     response = dockerflow_middleware.process_request(request)

--- a/tests/requirements/sanic.txt
+++ b/tests/requirements/sanic.txt
@@ -1,7 +1,7 @@
 # these are constrained by the files in tests/constraints/*.txt
 # to support a triple stack Django/Flask/Sanic
 aiohttp
-aioredis
+aioredis<2.0.0
 Sanic
 sanic_redis
 uvloop>=0.14.0rc1


### PR DESCRIPTION
This fixes #56, sort-of.  Checks shouldn't raise exceptions, and Django doesn't give any good way to identify checks before they've been invoked.  So, this at least reports the exceptional check as such, rather than just crashing.  However, there's no way to silence that report.