### PR TITLE
Drop default_app_config

### DIFF
--- a/src/dockerflow/django/__init__.py
+++ b/src/dockerflow/django/__init__.py
@@ -1,4 +1,3 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
-default_app_config = "dockerflow.django.apps.DockerFlowAppConfig"


### PR DESCRIPTION
Obsolete since Django 3.2 and removed in Django 4.1