### PR TITLE
Install dockerflow for docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,3 +13,5 @@ sphinx:
 python:
   install:
   - requirements: docs/requirements.txt
+  - method: pip
+    path: .


### PR DESCRIPTION
The new `.readthedocs.yml` flow needs to install the dockerflow project to build correctly. Maybe. I can see the [builds](https://readthedocs.org/projects/python-dockerflow/builds/), but do not have maintainer access to the RTD project.