### PR TITLE
docs: Upgrade sphinx-rtd-theme in build

### DIFF
--- a/tests/requirements/docs.txt
+++ b/tests/requirements/docs.txt
@@ -1,2 +1,3 @@
-Sphinx>=7.1
+Sphinx>=6
 sphinxcontrib-httpdomain
+sphinx-rtd-theme>=1.2.0


### PR DESCRIPTION
Another change to fix the [build on readthedocs.org](https://readthedocs.org/projects/python-dockerflow/builds/).