### PR TITLE
Fix docs about heartbeat status on warnings (200, not 5XX) 

### DIFF
--- a/docs/django.rst
+++ b/docs/django.rst
@@ -336,8 +336,8 @@ spec:
         }
       }
 
-   :statuscode 200: no error
-   :statuscode 500: there was a warning or error
+   :statuscode 200: no error, with potential warnings
+   :statuscode 500: there was an error
 
 .. http:get:: /__lbheartbeat__
 

--- a/docs/django.rst
+++ b/docs/django.rst
@@ -287,7 +287,7 @@ spec:
 .. http:get:: /__heartbeat__
 
    The heartbeat view will go through the list of configured Dockerflow
-   checks in the :ref:`DOCKERFLOW_CHECKS` setting, run each check, and, if 
+   checks in the :ref:`DOCKERFLOW_CHECKS` setting, run each check, and, if
    `settings.DEBUG` is `True`, add their results to a JSON response.
 
    The view will return HTTP responses with either a status code of 200 if

--- a/docs/fastapi.rst
+++ b/docs/fastapi.rst
@@ -241,7 +241,7 @@ spec:
         }
       }
 
-   :statuscode 200: no error
+   :statuscode 200: no error, with potential warnings
    :statuscode 500: there was an error
 
 .. http:get:: /__lbheartbeat__

--- a/docs/flask.rst
+++ b/docs/flask.rst
@@ -389,8 +389,8 @@ spec:
         }
       }
 
-   :statuscode 200: no error
-   :statuscode 500: there was a warning or error
+   :statuscode 200: no error, with potential warnings
+   :statuscode 500: there was an error
 
 .. http:get:: /__lbheartbeat__
 

--- a/docs/sanic.rst
+++ b/docs/sanic.rst
@@ -369,8 +369,8 @@ spec:
         }
       }
 
-   :statuscode 200: no error
-   :statuscode 500: there was a warning or error
+   :statuscode 200: no error, with potential warnings
+   :statuscode 500: there was an error
 
 .. http:get:: /__lbheartbeat__
 


### PR DESCRIPTION
All implementation follow this logic:

```py
if check_results.level < checks.ERROR:
        status_code = 200        
else:
        status_code = 500
```