### PR TITLE
Github Action status for each tox combination

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,13 +9,26 @@ on:
       - main
 
 jobs:
-  build:
-    name: build (Python ${{ matrix.python-version }})
+  get-tox-envlist:
     runs-on: ubuntu-latest
+    outputs:
+      envlist: ${{ steps.generate-tox-envlist.outputs.envlist }}
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox tox-gh-matrix
+      - id: generate-tox-envlist
+        run: python -m tox --gh-matrix
+
+  build:
+    name: Test ${{ matrix.tox.name }}
+    runs-on: ubuntu-latest
+    needs: get-tox-envlist
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        tox: ${{ fromJSON(needs.get-tox-envlist.outputs.envlist) }}
 
     # Service containers to run with `container-job`
     services:
@@ -36,22 +49,21 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+    - name: Setup Python ${{ matrix.tox.python.version }}
+      uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.tox.python.spec }}
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade tox tox-gh-actions
+        python -m pip install --upgrade tox
 
     - name: Tox tests
-      run: |
-        tox -v
+      run: python -m tox -v -e ${{ matrix.tox.name }}
 
     - name: Install codecov
       run: python -m pip install codecov
 
     - name: Upload coverage
-      run: python -m codecov --name "Python ${{ matrix.python-version }}"
+      run: python -m codecov --name "Python ${{ matrix.tox.python.spec }}"

--- a/tox.ini
+++ b/tox.ini
@@ -11,14 +11,6 @@ envlist =
     py{38,39,310,311}-fl{20,21,22}
     py{38,39,310,311}-s{21,22}
 
-[gh-actions]
-python =
-    3.8: py38
-    3.9: py39
-    3.10: py310
-    3.11: py311
-    3.12: py312
-
 [testenv]
 usedevelop = true
 pip_pre = true


### PR DESCRIPTION
The current GH Action setup with Tox is really tedious to get the tests outputs for a particular framework... ([example](https://github.com/mozilla-services/python-dockerflow/actions/runs/8098062937/job/22130609961))

**Before**

<img width="902" alt="Screenshot 2024-02-29 at 17 17 45" src="https://github.com/mozilla-services/python-dockerflow/assets/546692/5ab91367-0e3f-4f19-b6aa-8d65ab69a90c">

**After**

<img width="321" alt="Screenshot 2024-02-29 at 17 16 52" src="https://github.com/mozilla-services/python-dockerflow/assets/546692/53698250-be1a-44ab-bf3a-f81e86f58a61">
