### PR TITLE
Update Django docs

### DIFF
--- a/docs/django.rst
+++ b/docs/django.rst
@@ -427,6 +427,7 @@ The *MozLog* formatter will output ``Fields`` application-specific fields. It ca
         extra={"phase": "started", "host": host, "port": port}
     )
 
+.. _requests_correlation_id:
 
 Requests Correlation ID
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -435,7 +436,8 @@ A unique request ID is read from the ``X-Request-ID`` request header, and a UUID
 
 Leveraging the ``RequestIdFilter`` in logging configuration as shown above will add a ``rid`` field into the ``Fields`` entry of all log messages.
 
-The header name to obtain the request ID can be customized in settings:
+The header name to obtain the request ID can be
+`customized in settings <DOCKERFLOW_REQUEST_ID_HEADER_NAME>`_:
 
 .. code-block:: python
 
@@ -507,7 +509,24 @@ Defaults to:
         'dockerflow.django.checks.check_migrations_applied',
     ]
 
+.. _DOCKERFLOW_REQUEST_ID_HEADER_NAME:
+
+``DOCKERFLOW_REQUEST_ID_HEADER_NAME``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The case-insenstive name of the HTTP header referenced for identifying a
+request.  The default is `X-Request-ID`, used by the
+`Heroku router <https://devcenter.heroku.com/articles/http-request-id#how-it-works>`_.
+If the header is not set by the incoming request, a UUID is generated
+for the :ref:`requests correlation ID<requests_correlation_id>`.
+
+A good value is the header name used by your deployment infrastructure.
+For example, the Google Cloud Platform sets the W3C standard ``traceparent``
+header as well as a legacy ``X-Cloud-Trace-Context`` header for
+`trace context <cloud.google.com/trace/docs/trace-context>`_.
+
 .. _DOCKERFLOW_VERSION_CALLBACK:
+
 
 ``DOCKERFLOW_VERSION_CALLBACK``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/django.rst
+++ b/docs/django.rst
@@ -254,6 +254,7 @@ Health monitoring
 Health monitoring happens via three different views following the Dockerflow_
 spec:
 
+.. _http_get_version:
 .. http:get:: /__version__
 
    The view that serves the :ref:`version information <django-versions>`.
@@ -490,17 +491,6 @@ the section about `Using WhiteNoise with Django`_ in its documentation.
 Settings
 --------
 
-.. _DOCKERFLOW_VERSION_CALLBACK:
-
-``DOCKERFLOW_VERSION_CALLBACK``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The dotted import path for the callable that
-returns the content to return under ``/__version__``.
-
-Defaults to ``'dockerflow.version.get_version'`` which will be passed the
-``BASE_DIR`` setting by default.
-
 .. _DOCKERFLOW_CHECKS:
 
 ``DOCKERFLOW_CHECKS``
@@ -516,3 +506,13 @@ Defaults to:
         'dockerflow.django.checks.check_database_connected',
         'dockerflow.django.checks.check_migrations_applied',
     ]
+
+.. _DOCKERFLOW_VERSION_CALLBACK:
+
+``DOCKERFLOW_VERSION_CALLBACK``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The dotted import path for the callable that takes a
+`HttpRequest <https://docs.djangoproject.com/en/stable/ref/request-response/#httprequest-objects>`_
+and returns the :ref:`version content<django-versions>` to return under
+:ref:`__version__<http_get_version>`. This defaults to ``dockerflow.version.get_version``.

--- a/docs/django.rst
+++ b/docs/django.rst
@@ -313,7 +313,7 @@ spec:
    The check setup process is logged at the ``DEBUG`` level. Since failure
    details are omitted with ``DEBUG=False``, this logger should emit logs
    at ``WARNING`` or ``ERROR`` level in production, so that the logs can
-   be used to diagnose heartbear failures.
+   be used to diagnose heartbeat failures.
 
    **Custom Dockerflow checks:**
 

--- a/docs/django.rst
+++ b/docs/django.rst
@@ -51,10 +51,22 @@ To install ``python-dockerflow``'s Django support please follow these steps:
         # ...
     )
 
+#. (Optional) Add the healthcheck views to SECURE_REDIRECT_EXEMPT_, so they can
+   be used as `Kubernetes liveness checks`_::
+
+    SECURE_REDIRECT_EXEMPT = [
+        r"^__version__/?$",
+        r"^__heartbeat__/?$",
+        r"^__lbheartbeat__/?$",
+    ]
+
 #. :ref:`Configure logging <django-logging>` to use the
    :class:`~dockerflow.logging.JsonLogFormatter`
    logging formatter for the ``request.summary`` logger (you may have to
    extend your existing logging configuration!).
+
+.. _`Kubernetes liveness checks`: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+.. _SECURE_REDIRECT_EXEMPT: https://docs.djangoproject.com/en/stable/ref/settings/#secure-redirect-exempt
 
 .. _django-config:
 

--- a/docs/django.rst
+++ b/docs/django.rst
@@ -425,7 +425,7 @@ configure **at least** the ``request.summary`` logger that way::
                 'handlers': ['console'],
                 'level': 'DEBUG',
             },
-            'dockerflow.checks.register': {
+            'dockerflow': {
                 'handlers': ['console'],
                 'level': 'WARNING',
             },

--- a/docs/django.rst
+++ b/docs/django.rst
@@ -526,6 +526,15 @@ Defaults to:
         'dockerflow.django.checks.check_migrations_applied',
     ]
 
+.. _DOCKERFLOW_HEARTBEAT_FAILED_STATUS_CODE:
+
+``DOCKERFLOW_HEARTBEAT_FAILED_STATUS_CODE``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In the :ref:`__heartbeat__<http_get_heartbeat>` view, this setting
+is used to set the status code when a check fails at ``error`` or higher.
+If unset, the default is ``500`` for an Internal Server Error.
+
 .. _DOCKERFLOW_REQUEST_ID_HEADER_NAME:
 
 ``DOCKERFLOW_REQUEST_ID_HEADER_NAME``

--- a/docs/django.rst
+++ b/docs/django.rst
@@ -407,7 +407,8 @@ configure **at least** the ``request.summary`` logger that way::
         }
     }
 
-In order to include querystrings in the request summary log, set this flag in settings:
+In order to include querystrings in the request summary log, set
+:ref:`this flag <DOCKERFLOW_SUMMARY_LOG_QUERYSTRING>` in settings:
 
 .. code-block:: python
 
@@ -524,6 +525,15 @@ A good value is the header name used by your deployment infrastructure.
 For example, the Google Cloud Platform sets the W3C standard ``traceparent``
 header as well as a legacy ``X-Cloud-Trace-Context`` header for
 `trace context <cloud.google.com/trace/docs/trace-context>`_.
+
+.. _DOCKERFLOW_SUMMARY_LOG_QUERYSTRING:
+
+``DOCKERFLOW_SUMMARY_LOG_QUERYSTRING``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If set to ``True``, then the request summary log will include the querystring.
+This defaults to ``False``, in case there is user-sensitive information in
+some querystrings.
 
 .. _DOCKERFLOW_VERSION_CALLBACK:
 

--- a/docs/django.rst
+++ b/docs/django.rst
@@ -472,7 +472,7 @@ Requests Correlation ID
 
 A unique request ID is read from the ``X-Request-ID`` request header, and a UUID4 value is generated if unset.
 
-Leveraging the ``RequestIdFilter`` in logging configuration as shown above will add a ``rid`` field into the ``Fields`` entry of all log messages.
+Leveraging the ``RequestIdLogFilter`` in logging configuration as shown above will add a ``rid`` field into the ``Fields`` entry of all log messages.
 
 The header name to obtain the request ID can be
 `customized in settings <DOCKERFLOW_REQUEST_ID_HEADER_NAME>`_:

--- a/docs/django.rst
+++ b/docs/django.rst
@@ -409,7 +409,7 @@ configure **at least** the ``request.summary`` logger that way::
         },
         'filters': {
             'request_id': {
-                '()': 'dockerflow.logging.RequestIdFilter',
+                '()': 'dockerflow.logging.RequestIdLogFilter',
             },
         },
         'handlers': {

--- a/docs/django.rst
+++ b/docs/django.rst
@@ -561,3 +561,11 @@ The dotted import path for the callable that takes a
 `HttpRequest <https://docs.djangoproject.com/en/stable/ref/request-response/#httprequest-objects>`_
 and returns the :ref:`version content<django-versions>` to return under
 :ref:`__version__<http_get_version>`. This defaults to ``dockerflow.version.get_version``.
+
+``SILENCED_SYSTEM_CHECKS``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The standard Django setting SILENCED_SYSTEM_CHECKS_ is used by the
+:ref:`__heartbeat__<http_get_heartbeat>` view to omit the named checks.
+
+.. _SILENCED_SYSTEM_CHECKS: https://docs.djangoproject.com/en/stable/ref/settings/#silenced-system-checks

--- a/docs/django.rst
+++ b/docs/django.rst
@@ -42,14 +42,14 @@ To install ``python-dockerflow``'s Django support please follow these steps:
 
    .. seealso:: :ref:`django-versions` for more information
 
-#. Add the ``DockerflowMiddleware`` to your ``MIDDLEWARE_CLASSES`` or
-   ``MIDDLEWARE`` setting::
+#. Add the ``DockerflowMiddleware`` to your ``MIDDLEWARE`` setting::
 
-    MIDDLEWARE_CLASSES = (
+    MIDDLEWARE = [
         # ...
+        # 'django.middleware.security.SecurityMiddleware',
         'dockerflow.django.middleware.DockerflowMiddleware',
         # ...
-    )
+    ]
 
 #. (Optional) Add the healthcheck views to SECURE_REDIRECT_EXEMPT_, so they can
    be used as `Kubernetes liveness checks`_::

--- a/docs/django.rst
+++ b/docs/django.rst
@@ -464,9 +464,9 @@ in your Django projet:
 
        STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
-#. Add the middleware to your ``MIDDLEWARE`` (or ``MIDDLEWARE_CLASSES``) setting::
+#. Add the middleware to your ``MIDDLEWARE`` setting::
 
-       MIDDLEWARE_CLASSES = [
+       MIDDLEWARE = [
            # 'django.middleware.security.SecurityMiddleware',
            'whitenoise.middleware.WhiteNoiseMiddleware',
            # ...

--- a/docs/django.rst
+++ b/docs/django.rst
@@ -284,11 +284,12 @@ spec:
    :statuscode 200: no error
    :statuscode 404: a version.json wasn't found
 
+.. _http_get_heartbeat:
 .. http:get:: /__heartbeat__
 
    The heartbeat view will go through the list of configured Dockerflow
    checks in the :ref:`DOCKERFLOW_CHECKS` setting, run each check, and, if
-   `settings.DEBUG` is `True`, add their results to a JSON response.
+   ``settings.DEBUG`` is ``True``, add their results to a JSON response.
 
    The view will return HTTP responses with either a status code of 200 if
    all checks ran successfully or 500 if there was one or more warnings or
@@ -494,13 +495,28 @@ the section about `Using WhiteNoise with Django`_ in its documentation.
 Settings
 --------
 
+``DEBUG``
+~~~~~~~~~
+
+The standard Django setting DEBUG_ is referenced by the
+:ref:`__heartbeat__<http_get_heartbeat>` view. If it is set to ``True``, then:
+
+- Django's deployment checks are run. These are the additional checks ran by
+  including the ``--deploy`` flag, such as ``python manage.py check --deploy``.
+
+- The ``checks`` and ``details`` objects are omitted from the JSON response,
+  leaving only the ``status`` of ``ok``, ``warning`` or ``error``.
+
+.. _DEBUG: https://docs.djangoproject.com/en/stable/ref/settings/#debug
+
 .. _DOCKERFLOW_CHECKS:
 
 ``DOCKERFLOW_CHECKS``
 ~~~~~~~~~~~~~~~~~~~~~
 
 A list of dotted import paths to register during
-Django setup, to be used in the rendering of the ``/__heartbeat__`` view.
+Django setup, to be used in the rendering of the
+:ref:`__heartbeat__<http_get_heartbeat>` view.
 Defaults to:
 
 .. code-block:: python

--- a/docs/django.rst
+++ b/docs/django.rst
@@ -295,6 +295,14 @@ spec:
    all checks ran successfully or 500 if there was one or more warnings or
    errors returned by the checks.
 
+   The check processes will log to ``dockerflow.checks.register``. Failed
+   checks that cause the heartbeat to fail are logged at ``ERROR`` level
+   or higher. Successful checks are logged at ``INFO`` level and higher.
+   The check setup process is logged at the ``DEBUG`` level. Since failure
+   details are omitted with ``DEBUG=False``, this logger should emit logs
+   at ``WARNING`` or ``ERROR`` level in production, so that the logs can
+   be used to diagnose heartbear failures.
+
    **Custom Dockerflow checks:**
 
    To write your own custom Dockerflow checks, please follow the documentation
@@ -312,7 +320,7 @@ spec:
       GET /__heartbeat__ HTTP/1.1
       Host: example.com
 
-   **Example response**:
+   **Example response, DEBUG=True**:
 
    .. sourcecode:: http
 
@@ -335,6 +343,18 @@ spec:
             }
           }
         }
+      }
+
+   **Example response, DEBUG=False**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 500 Internal Server Error
+      Vary: Accept-Encoding
+      Content-Type: application/json
+
+      {
+        "status": "warning"
       }
 
    :statuscode 200: no error, with potential warnings
@@ -404,6 +424,10 @@ configure **at least** the ``request.summary`` logger that way::
             'request.summary': {
                 'handlers': ['console'],
                 'level': 'DEBUG',
+            },
+            'dockerflow.checks.register': {
+                'handlers': ['console'],
+                'level': 'WARNING',
             },
         }
     }

--- a/docs/django.rst
+++ b/docs/django.rst
@@ -7,9 +7,6 @@ Django projects that want to follow the Dockerflow specs:
 - A Python logging formatter following the `mozlog`_ format to be used in
   the ``LOGGING`` setting.
 
-- A middleware to emit `request.summary`_ log records based on request specific
-  data.
-
 - Views for health monitoring:
 
   - ``/__version__`` - Serves a ``version.json`` file
@@ -19,6 +16,8 @@ Django projects that want to follow the Dockerflow specs:
 
   - ``/__lbheartbeat__`` - Retuns a HTTP 200 response
 
+- A middleware to emit `request.summary`_ log records based on request specific
+  data, and to serve the health monitoring views.
 
 - Signals for passed and failed heartbeats.
 

--- a/docs/fastapi.rst
+++ b/docs/fastapi.rst
@@ -300,7 +300,7 @@ for at least the ``request.summary`` logger:
         },
         'filters': {
             'request_id': {
-                '()': 'dockerflow.logging.RequestIdFilter',
+                '()': 'dockerflow.logging.RequestIdLogFilter',
             },
         },
         'handlers': {
@@ -346,7 +346,7 @@ Requests Correlation ID
 
 A unique request ID is read from the ``X-Request-ID`` request header, and a UUID4 value is generated if unset.
 
-Leveraging the ``RequestIdFilter`` in logging configuration as shown above will add a ``rid`` field into the ``Fields`` entry of all log messages.
+Leveraging the ``RequestIdLogFilter`` in logging configuration as shown above will add a ``rid`` field into the ``Fields`` entry of all log messages.
 
 The header name to obtain the request ID can be customized in settings:
 

--- a/docs/flask.rst
+++ b/docs/flask.rst
@@ -443,7 +443,7 @@ for at least the ``request.summary`` logger::
         },
         'filters': {
             'request_id': {
-                '()': 'dockerflow.logging.RequestIdFilter',
+                '()': 'dockerflow.logging.RequestIdLogFilter',
             },
         },
         'handlers': {
@@ -486,7 +486,7 @@ Requests Correlation ID
 
 A unique request ID is read from the ``X-Request-ID`` request header, and a UUID4 value is generated if unset.
 
-Leveraging the ``RequestIdFilter`` in logging configuration as shown above will add a ``rid`` field into the ``Fields`` entry of all log messages.
+Leveraging the ``RequestIdLogFilter`` in logging configuration as shown above will add a ``rid`` field into the ``Fields`` entry of all log messages.
 
 The header name to obtain the request ID can be customized in settings:
 

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -41,7 +41,7 @@ this::
         },
         'filters': {
             'request_id': {
-                '()': 'dockerflow.logging.RequestIdFilter',
+                '()': 'dockerflow.logging.RequestIdLogFilter',
             },
         },
         'handlers': {
@@ -90,7 +90,7 @@ thing as the dictionary based configuratio above:
     keys = request_id
 
     [filter_request_id]
-    class = dockerflow.logging.RequestIdFilter
+    class = dockerflow.logging.RequestIdLogFilter
 
     [logger_root]
     level = INFO

--- a/docs/sanic.rst
+++ b/docs/sanic.rst
@@ -423,7 +423,7 @@ for at least the ``request.summary`` logger::
         },
         'filters': {
             'request_id': {
-                '()': 'dockerflow.logging.RequestIdFilter',
+                '()': 'dockerflow.logging.RequestIdLogFilter',
             },
         },
         'handlers': {
@@ -485,7 +485,7 @@ Requests Correlation ID
 
 A unique request ID is read from the ``X-Request-ID`` request header, and a UUID4 value is generated if unset.
 
-Leveraging the ``RequestIdFilter`` in logging configuration as shown above will add a ``rid`` field into the ``Fields`` entry of all log messages.
+Leveraging the ``RequestIdLogFilter`` in logging configuration as shown above will add a ``rid`` field into the ``Fields`` entry of all log messages.
 
 The header name to obtain the request ID can be customized in settings:
 


### PR DESCRIPTION
This refreshes the Django docs, and adds some information that may be useful.

* Add that the [DockerflowMiddleware](https://github.com/mozilla-services/python-dockerflow/blob/9014f6ef4e86c913fcfcbc4b3de557d7ab7b9eca/src/dockerflow/django/middleware.py#L25) also serves the `__version__`, `__heartbeat__` and `__lbheartbeat__` views. In [mozilla/fx-private-relay PR #4345](https://github.com/mozilla/fx-private-relay/pull/4345), we removed some duplicate versions of the views that were not called because of the middleware.
* Document that check results are logged to ``dockerflow.checks.register``. This is how you can see what checks are failing if ``DEBUG=False``.
* Add an example heartbeat response when ``DEBUG=False``.
* Add ``dockerflow`` to the sample logging configuration. Without this (and without a ``root`` handler), these logs are discarded, making it impossible to debug heartbeat issues.
* Drop reference to ``MIDDLEWARE_CLASSES``, which was removed in Django 2.0 in 2017.
* Add ``SECURE_REDIRECT_EXEMPT`` for Kubernetes deployments.
* Expand the Settings section to document all the added settings and a few Django ones as well:
  - Add Django's setting `DEBUG`, to document how it affects what checks heartbeat runs, and the data included in the heartbeat response.
  - Add `DOCKERFLOW_HEARTBEAT_FAILED_STATUS_CODE`, previously mentioned in the heartbeat view section
  - Add `DOCKERFLOW_REQUEST_ID_HEADER_NAME`, previously mentioned in the "Requests Correlation ID" section. Add why you may want to change it for different deployment environments.
  - Add `DOCKERFLOW_SUMMARY_LOG_QUERYSTRING`, previously mentioned in the Logging section.
  - Move `DOCKERFLOW_VERSION_CALLBACK` down to alphabetical order
  - Add Django's setting `SILENCED_SYSTEM_CHECKS`, used but not previously documented.
  - I did not add `BASE_DIR`, since there is no Django docs, because Django maintainers say that is a constant, not a setting (https://code.djangoproject.com/ticket/31387).