### PR TITLE
Fix docstrings about heartbeat status on warnings (200, not 5XX)

### DIFF
--- a/src/dockerflow/django/views.py
+++ b/src/dockerflow/django/views.py
@@ -50,8 +50,8 @@ def heartbeat(request):
     Runs all the Django checks and returns a JsonResponse with either
     a status code of 200 or 500 depending on the results of the checks.
 
-    Any check that returns a warning or worse (error, critical) will
-    return a 500 response.
+    Any check that returns an error or worse (critical) will return
+    a 500 response.
     """
     checks_to_run = (
         (check.__name__, lambda: check(app_configs=None))

--- a/src/dockerflow/flask/app.py
+++ b/src/dockerflow/flask/app.py
@@ -314,8 +314,8 @@ class Dockerflow(object):
         Runs all the registered checks and returns a JSON response with either
         a status code of 200 or 500 depending on the results of the checks.
 
-        Any check that returns a warning or worse (error, critical) will
-        return a 500 response.
+        Any check that returns an error or worse (critical) will return
+        a 500 response.
         """
         FAILED_STATUS_CODE = int(
             flask.current_app.config.get(

--- a/src/dockerflow/sanic/app.py
+++ b/src/dockerflow/sanic/app.py
@@ -213,8 +213,8 @@ class Dockerflow(object):
         Runs all the registered checks and returns a JSON response with either
         a status code of 200 or 500 depending on the results of the checks.
 
-        Any check that returns a warning or worse (error, critical) will
-        return a 500 response.
+        Any check that returns an error or worse (critical) will return
+        a 500 response.
         """
         FAILED_STATUS_CODE = int(
             request.app.config.get("DOCKERFLOW_HEARTBEAT_FAILED_STATUS_CODE", "500")


### PR DESCRIPTION
All implementations of heartbeat now return a 500 response only for errors or worse. Docstrings needs to be updated.
